### PR TITLE
Fix Semantic Errors: DELETE operations cannot have a requestBody

### DIFF
--- a/OpenApiDefinitions/keycloak-18.0.0.json
+++ b/OpenApiDefinitions/keycloak-18.0.0.json
@@ -2111,18 +2111,6 @@
           "ScopeMappedClient"
         ],
         "description": "/\nAdd client-level roles to the client's scope\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -2134,18 +2122,6 @@
           "ScopeMappedClient"
         ],
         "description": "/\nRemove client-level roles from the client's scope.\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -2323,18 +2299,6 @@
           "ScopeMapped"
         ],
         "description": "/\nAdd a set of realm-level roles to the client's scope\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -2346,18 +2310,6 @@
           "ScopeMapped"
         ],
         "description": "/\nRemove a set of realm-level roles from the client's scope\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -2961,18 +2913,6 @@
           "ScopeMappedClient"
         ],
         "description": "/\nAdd client-level roles to the client's scope\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -2984,18 +2924,6 @@
           "ScopeMappedClient"
         ],
         "description": "/\nRemove client-level roles from the client's scope.\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -3173,18 +3101,6 @@
           "ScopeMapped"
         ],
         "description": "/\nAdd a set of realm-level roles to the client's scope\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -3196,18 +3112,6 @@
           "ScopeMapped"
         ],
         "description": "/\nRemove a set of realm-level roles from the client's scope\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -5374,18 +5278,6 @@
           "RoleContainer"
         ],
         "description": "/\nAdd a composite to the role\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -5418,18 +5310,6 @@
           "RoleContainer"
         ],
         "description": "/\nRemove roles from the role's composite\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -5870,18 +5750,6 @@
           "ScopeMappedClient"
         ],
         "description": "/\nAdd client-level roles to the client's scope\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -5893,18 +5761,6 @@
           "ScopeMappedClient"
         ],
         "description": "/\nRemove client-level roles from the client's scope.\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -6079,18 +5935,6 @@
           "ScopeMapped"
         ],
         "description": "/\nAdd a set of realm-level roles to the client's scope\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -6102,18 +5946,6 @@
           "ScopeMapped"
         ],
         "description": "/\nRemove a set of realm-level roles from the client's scope\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -7586,18 +7418,6 @@
           "ClientRoleMappings"
         ],
         "description": "/\nAdd client-level roles to the user role mapping\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -7609,18 +7429,6 @@
           "ClientRoleMappings"
         ],
         "description": "/\nDelete client-level roles from user role mapping\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -7795,18 +7603,6 @@
           "RoleMapper"
         ],
         "description": "/\nAdd realm-level role mappings to the user\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -7818,18 +7614,6 @@
           "RoleMapper"
         ],
         "description": "/\nDelete realm-level role mappings\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -9066,18 +8850,6 @@
           "RoleById"
         ],
         "description": "/\nMake the role a composite role by associating some child roles\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -9135,18 +8907,6 @@
           "RoleById"
         ],
         "description": "/\nRemove a set of roles from the role's composite\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -9418,18 +9178,6 @@
           "RoleContainer"
         ],
         "description": "/\nAdd a composite to the role\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -9462,18 +9210,6 @@
           "RoleContainer"
         ],
         "description": "/\nRemove roles from the role's composite\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -11437,18 +11173,6 @@
           "ClientRoleMappings"
         ],
         "description": "/\nAdd client-level roles to the user role mapping\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -11460,18 +11184,6 @@
           "ClientRoleMappings"
         ],
         "description": "/\nDelete client-level roles from user role mapping\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -11646,18 +11358,6 @@
           "RoleMapper"
         ],
         "description": "/\nAdd realm-level role mappings to the user\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"
@@ -11669,18 +11369,6 @@
           "RoleMapper"
         ],
         "description": "/\nDelete realm-level role mappings\n\n",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RoleRepresentation"
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "2XX": {
             "description": "Success"

--- a/OpenApiDefinitions/keycloak-18.0.0.yml
+++ b/OpenApiDefinitions/keycloak-18.0.0.yml
@@ -1337,13 +1337,6 @@ paths:
       tags:
         - ScopeMappedClient
       description: "/\nRemove client-level roles from the client's scope.\n\n"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/RoleRepresentation'
       responses:
         2XX:
           description: Success
@@ -1470,13 +1463,6 @@ paths:
       tags:
         - ScopeMapped
       description: "/\nRemove a set of realm-level roles from the client's scope\n\n"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/RoleRepresentation'
       responses:
         2XX:
           description: Success
@@ -1871,13 +1857,6 @@ paths:
       tags:
         - ScopeMappedClient
       description: "/\nRemove client-level roles from the client's scope.\n\n"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/RoleRepresentation'
       responses:
         2XX:
           description: Success
@@ -2004,13 +1983,6 @@ paths:
       tags:
         - ScopeMapped
       description: "/\nRemove a set of realm-level roles from the client's scope\n\n"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/RoleRepresentation'
       responses:
         2XX:
           description: Success
@@ -3386,13 +3358,6 @@ paths:
       tags:
         - RoleContainer
       description: "/\nRemove roles from the role's composite\n\n"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/RoleRepresentation'
       responses:
         2XX:
           description: Success
@@ -3684,13 +3649,6 @@ paths:
       tags:
         - ScopeMappedClient
       description: "/\nRemove client-level roles from the client's scope.\n\n"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/RoleRepresentation'
       responses:
         2XX:
           description: Success
@@ -3814,13 +3772,6 @@ paths:
       tags:
         - ScopeMapped
       description: "/\nRemove a set of realm-level roles from the client's scope\n\n"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/RoleRepresentation'
       responses:
         2XX:
           description: Success
@@ -4752,13 +4703,6 @@ paths:
       tags:
         - ClientRoleMappings
       description: "/\nDelete client-level roles from user role mapping\n\n"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/RoleRepresentation'
       responses:
         2XX:
           description: Success
@@ -4882,13 +4826,6 @@ paths:
       tags:
         - RoleMapper
       description: "/\nDelete realm-level role mappings\n\n"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/RoleRepresentation'
       responses:
         2XX:
           description: Success
@@ -5700,13 +5637,6 @@ paths:
       tags:
         - RoleById
       description: "/\nRemove a set of roles from the role's composite\n\n"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/RoleRepresentation'
       responses:
         2XX:
           description: Success
@@ -5905,13 +5835,6 @@ paths:
       tags:
         - RoleContainer
       description: "/\nRemove roles from the role's composite\n\n"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/RoleRepresentation'
       responses:
         2XX:
           description: Success
@@ -7155,13 +7078,6 @@ paths:
       tags:
         - ClientRoleMappings
       description: "/\nDelete client-level roles from user role mapping\n\n"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/RoleRepresentation'
       responses:
         2XX:
           description: Success
@@ -7285,13 +7201,6 @@ paths:
       tags:
         - RoleMapper
       description: "/\nDelete realm-level role mappings\n\n"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/RoleRepresentation'
       responses:
         2XX:
           description: Success


### PR DESCRIPTION
Fixing serval errors, created by the generator:

- Semantic error at paths./{realm}/client-scopes/{id}/scope-mappings/clients/{client}.delete.requestBody
DELETE operations cannot have a requestBody.
- Semantic error at paths./{realm}/client-scopes/{id}/scope-mappings/realm.delete.requestBody
DELETE operations cannot have a requestBody.
- Semantic error at paths./{realm}/client-templates/{id}/scope-mappings/clients/{client}.delete.requestBody
DELETE operations cannot have a requestBody.
- Semantic error at paths./{realm}/client-templates/{id}/scope-mappings/realm.delete.requestBody
DELETE operations cannot have a requestBody.
- Semantic error at paths./{realm}/clients/{id}/roles/{role-name}/composites.delete.requestBody
DELETE operations cannot have a requestBody.
- Semantic error at paths./{realm}/clients/{id}/scope-mappings/clients/{client}.delete.requestBody
DELETE operations cannot have a requestBody.
- Semantic error at paths./{realm}/clients/{id}/scope-mappings/realm.delete.requestBody
DELETE operations cannot have a requestBody.
- Semantic error at paths./{realm}/groups/{id}/role-mappings/clients/{client}.delete.requestBody
DELETE operations cannot have a requestBody.
- Semantic error at paths./{realm}/groups/{id}/role-mappings/realm.delete.requestBody
DELETE operations cannot have a requestBody.
- Semantic error at paths./{realm}/roles-by-id/{role-id}/composites.delete.requestBody
DELETE operations cannot have a requestBody.
- Semantic error at paths./{realm}/roles/{role-name}/composites.delete.requestBody
DELETE operations cannot have a requestBody.
- Semantic error at paths./{realm}/users/{id}/role-mappings/clients/{client}.delete.requestBody
DELETE operations cannot have a requestBody.
- Semantic error at paths./{realm}/users/{id}/role-mappings/realm.delete.requestBody
DELETE operations cannot have a requestBody.`